### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ spec:
 At this point we're ready to apply these changes. ArgoCD will attempt to pick up changes from the specified repository in the `application.yaml`. This means it's time to commit and push our code to that repository.
 
 ```bash
-# kubernetes/apps/app1/
 kubectl apply -f application.yaml
 ```
 


### PR DESCRIPTION
as said before kubect commandsl is not directory dependent so I ran it from this directory and got the app created in argo cd succesfully  C:\source\kubernetes\apps\app1>kubectl apply -f application.yaml application.argoproj.io/app1 created